### PR TITLE
Add version pinning via arguments mod

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,10 +258,10 @@ Use **AppID**`-custom.txt` to add extra arguments to the installer (with `-h` si
 
 This uses the **content** as a native **winget --custom** parameter when upgrading.
 
-#### Arguments (Winget-level parameters) ⭐ NEW
+#### Arguments (Winget-level parameters)
 Use **AppID**`-arguments.txt` to pass **winget parameters** (not installer arguments, with `-h` silent mode).
 
-💡 **Locale Tip:** Many applications revert to English or system default language during WAU upgrades because winget doesn't remember the original installation locale. To prevent this:
+**Locale Tip:** Many applications revert to English or system default language during WAU upgrades because winget doesn't remember the original installation locale. To prevent this:
 - **Best solution:** Use locale-specific package IDs in `included_apps.txt` (e.g., `Mozilla.Firefox.sv-SE` instead of `Mozilla.Firefox`)
 - **Alternative:** Create `{AppID}-arguments.txt` with `--locale` parameter to force language on every upgrade
 
@@ -278,16 +278,17 @@ Use **AppID**`-arguments.txt` to pass **winget parameters** (not installer argum
 
 **Common use cases:**
 - `--locale <locale>` - Force application language (e.g., `pl-PL`, `en-US`, `de-DE`)
-  - 💡 **Recommended alternative:** Use locale-specific package IDs when available (e.g., `Mozilla.Firefox.sv-SE`, `Mozilla.Firefox.de`, `Mozilla.Firefox.ESR.pl`) to get latest versions
+  - **Recommended alternative:** Use locale-specific package IDs when available (e.g., `Mozilla.Firefox.sv-SE`, `Mozilla.Firefox.de`, `Mozilla.Firefox.ESR.pl`) to get latest versions
 - `--skip-dependencies` - Skip dependency installations when they conflict
 - `--architecture <arch>` - Force architecture (`x86`, `x64`, `arm64`)
 - `--version <version>` - Pin to specific version
+  - If used `$app.AvailableVersion = <version>`, fixing https://github.com/Romanitho/Winget-AutoUpdate/issues/1125
 - `--ignore-security-hash` - Bypass hash verification
 - `--ignore-local-archive-malware-scan` - Skip AV scanning
 
-⚠️ **Important:** When combining `--locale` and `--version`, the specific version must have an installer available for that locale. Not all versions support all locales. Check available versions with `winget show --id <AppID> --versions`.
+**Important:** When combining `--locale` and `--version`, the specific version must have an installer available for that locale. Not all versions support all locales. Check available versions with `winget show --id <AppID> --versions`.
 
-💡 **Locale Best Practice:** Search for locale-specific packages with `winget search <AppName>` to see if your language has a dedicated package ID (e.g., `Mozilla.Firefox.sv-SE` for Swedish Firefox). These packages are maintained with the latest versions in your preferred language.
+**Locale Best Practice:** Search for locale-specific packages with `winget search <AppName>` to see if your language has a dedicated package ID (e.g., `Mozilla.Firefox.sv-SE` for Swedish Firefox). These packages are maintained with the latest versions in your preferred language.
 
 **Command-line usage:** You can also pass arguments when calling `Winget-Install.ps1`:
 ```powershell

--- a/Sources/Winget-AutoUpdate/functions/Update-App.ps1
+++ b/Sources/Winget-AutoUpdate/functions/Update-App.ps1
@@ -30,6 +30,19 @@ Function Update-App ($app) {
         return @{ Params = $params + "-h"; Log = $Command }
     }
 
+    # Load mods
+    $ModsPreInstall, $ModsOverride, $ModsCustom, $ModsArguments, $ModsUpgrade, $ModsInstall, $ModsInstalled, $ModsNotInstalled = Test-Mods $app.Id
+
+    # If arguments mod specifies --version, pin AvailableVersion to that value
+    if ($ModsArguments -match '(?:^|\s)--version\s+(\S+)') {
+        $app.AvailableVersion = $Matches[1]
+        Write-ToLog "-> $($app.Name) version pinned to $($app.AvailableVersion) via arguments mod" "DarkYellow"
+        if ($app.Version -eq $app.AvailableVersion) {
+            Write-ToLog "$($app.Name) $($app.Version) is already the pinned version, skipping." "Green"
+            return
+        }
+    }
+
     # Get release notes for notification button
     $ReleaseNoteURL = Get-AppInfo $app.Id
     $Button1Text = if ($ReleaseNoteURL) { $NotifLocale.local.outputs.output[10].message } else { $null }
@@ -39,9 +52,6 @@ Function Update-App ($app) {
     Start-NotifTask -Title ($NotifLocale.local.outputs.output[2].title -f $app.Name) `
         -Message ($NotifLocale.local.outputs.output[2].message -f $app.Version, $app.AvailableVersion) `
         -MessageType "info" -Balise $app.Name -Button1Action $ReleaseNoteURL -Button1Text $Button1Text
-
-    # Load mods
-    $ModsPreInstall, $ModsOverride, $ModsCustom, $ModsArguments, $ModsUpgrade, $ModsInstall, $ModsInstalled, $ModsNotInstalled = Test-Mods $app.Id
 
     Write-ToLog "##########   WINGET UPGRADE: $($app.Id)   ##########" "Gray"
 

--- a/Sources/Winget-AutoUpdate/mods/_AppID-arguments-template.txt
+++ b/Sources/Winget-AutoUpdate/mods/_AppID-arguments-template.txt
@@ -48,7 +48,7 @@
 # --architecture x86
 # --architecture arm64
 
-# 4. Pin to specific version (but WAU will still try upgrading...)
+# 4. Pin to specific version (if used $app.AvailableVersion = <version>)
 # Prevent auto-upgrade to latest:
 # --version 120.0.1
 # WARNING: When combining --locale and --version, the specific version


### PR DESCRIPTION
## Summary
- If `<AppId>-arguments.txt` contains `--version <x.y.z>`, `AvailableVersion` is pinned to that version before any notification or install step
- If the currently installed version already matches the pinned version, the update is skipped silently
- Mods are now loaded before the "Updating..." notification so the correct (pinned) version is shown from the start

## Test plan
- [ ] Create `<AppId>-arguments.txt` with `--version 1.2.3` and verify WAU installs exactly that version
- [ ] With the pinned version already installed, verify WAU logs "already the pinned version, skipping" and does nothing
- [ ] Without `--version` in arguments, verify existing behaviour is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)